### PR TITLE
feat: Add tracing to NodeDB for efficient slot detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ path = "example/custom_account.rs"
 name = "approval"
 path = "example/approval.rs"
 
+[[bin]]
+name = "get_balance_slot"
+path = "example/get_balance_slot.rs"
+
 [dependencies]
 anyhow = "1.0.97"
 eyre = "0.6.12"

--- a/example/get_balance_slot.rs
+++ b/example/get_balance_slot.rs
@@ -1,0 +1,76 @@
+use std::time::Instant;
+
+use alloy::primitives::{address, U256};
+use alloy::sol;
+use alloy::sol_types::{SolCall, SolValue};
+use eyre::anyhow;
+use eyre::Result;
+use node_db::NodeDB;
+use revm::context::result::ExecutionResult;
+use revm::primitives::{Address, TxKind};
+use revm::{Context, DatabaseRef, ExecuteEvm, MainBuilder, MainContext};
+
+sol! {
+    #[sol(rpc)]
+    contract WETH {
+        function balanceOf(address account) external view returns (uint256);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+
+    // on chain addresses
+    let account = address!("0000000000000000000000000000000000000001");
+    let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+
+    // construct the database
+    let database_path = std::env::var("DB_PATH").unwrap().parse().unwrap();
+    let mut nodedb = NodeDB::new(database_path).unwrap();
+    nodedb.enable_tracing()?;
+
+    let start = Instant::now();
+    let balance_slot = get_balance_slot(&mut nodedb, weth, account)?;
+    let duration = start.elapsed();
+
+    println!(
+        "Resolved WETH balance slot: 0x{:x} (in {:?})",
+        balance_slot, duration
+    );
+
+    Ok(())
+}
+
+fn get_balance_slot(nodedb: &mut NodeDB, token: Address, account: Address) -> Result<U256> {
+    nodedb.enable_tracing()?;
+
+    let balanceof_calldata = WETH::balanceOfCall { account }.abi_encode();
+    let mut evm = Context::mainnet()
+        .with_db(&mut *nodedb)
+        .modify_tx_chained(|tx| {
+            tx.caller = address!("0000000000000000000000000000000000000000");
+            tx.kind = TxKind::Call(token);
+            tx.data = balanceof_calldata.into();
+        })
+        .build_mainnet();
+    let ref_tx = evm.replay()?;
+
+    let balance = match ref_tx.result {
+        ExecutionResult::Success { output, .. } => U256::abi_decode(output.data(), false)?,
+        result => return Err(anyhow!("balanceOf failed: {result:?}")),
+    };
+
+    let accessed_slots = nodedb.get_accessed_slots(token)?;
+    nodedb.disable_tracing();
+
+    // Identify the storage slot whose value matches the expected balance
+    for slot in &accessed_slots {
+        let slot_value = nodedb.storage_ref(token, *slot)?;
+        if slot_value == balance {
+            return Ok(*slot);
+        }
+    }
+
+    Err(anyhow!("Balance slot not found among accessed slots"))
+}

--- a/example/get_balance_slot.rs
+++ b/example/get_balance_slot.rs
@@ -28,7 +28,6 @@ async fn main() -> Result<()> {
     // construct the database
     let database_path = std::env::var("DB_PATH").unwrap().parse().unwrap();
     let mut nodedb = NodeDB::new(database_path).unwrap();
-    nodedb.enable_tracing()?;
 
     let start = Instant::now();
     let balance_slot = get_balance_slot(&mut nodedb, weth, account)?;


### PR DESCRIPTION
This commit adds a tracing mechanism to NodeDB to improve the efficiency
of storage slot identification, debugging, etc.

Key changes:
- Added `accessed_slots: RwLock<HashMap<Address, HashSet<U256>>>` to track
  slots accessed per address during EVM execution.
- Added `tracing_enabled: bool` to toggle tracing on/off.
- Modified `storage` and `storage_ref` to log accessed slots when tracing
  is enabled.
- Updated `get_accessed_slots` to retrieve slots for a specific address.
- Added a `get_balance_slot` example demonstrating how to retrieve the WETH
  balance slot using tracing.