### PR TITLE
chore: Introduce NodeDBBackend trait for abstracted database access

### DIFF
--- a/example/approval.rs
+++ b/example/approval.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
 use alloy_primitives::{address, U256};
-use alloy_sol_types::{SolCall, SolValue, sol};
+use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
 use revm::primitives::{keccak256, TxKind};
@@ -26,8 +29,10 @@ async fn main() -> Result<()> {
     let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 
     // construct the database
-    let database_path = std::env::var("DB_PATH").unwrap().parse().unwrap();
-    let mut nodedb = NodeDB::new(database_path).unwrap();
+    let database_path: String = std::env::var("DB_PATH").unwrap();
+    let backend =
+        RethBackend::new(Path::new(database_path.as_str())).expect("failed to open Reth database");
+    let mut nodedb = NodeDB::new(backend);
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());

--- a/example/custom_slot.rs
+++ b/example/custom_slot.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
 use alloy_primitives::{address, U256};
-use alloy_sol_types::{SolCall, SolValue, sol};
+use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
 use revm::primitives::{keccak256, TxKind};
@@ -22,8 +25,10 @@ async fn main() -> Result<()> {
     let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 
     // construct the database
-    let database_path = std::env::var("DB_PATH").unwrap().parse().unwrap();
-    let mut nodedb = NodeDB::new(database_path).unwrap();
+    let database_path: String = std::env::var("DB_PATH").unwrap();
+    let backend =
+        RethBackend::new(Path::new(database_path.as_str())).expect("failed to open Reth database");
+    let mut nodedb = NodeDB::new(backend);
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());

--- a/example/quote.rs
+++ b/example/quote.rs
@@ -1,8 +1,11 @@
+use std::path::Path;
+
 use alloy_primitives::{address, U256};
-use alloy_sol_types::{SolCall, SolValue, sol};
+use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
 use node_db::NodeDB;
+use node_db::RethBackend;
 use revm::context::result::ExecutionResult;
 use revm::primitives::TxKind;
 use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
@@ -27,8 +30,10 @@ async fn main() -> Result<()> {
     let uniswap = address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D");
 
     // setup the db
-    let database_path: String = std::env::var("DB_PATH").unwrap().parse().unwrap();
-    let mut nodedb = NodeDB::new(database_path).unwrap();
+    let database_path: String = std::env::var("DB_PATH").unwrap();
+    let backend =
+        RethBackend::new(Path::new(database_path.as_str())).expect("failed to open Reth database");
+    let mut nodedb = NodeDB::new(backend);
 
     // construct the calldata for weth->usdc quote
     let out_call = Quote::getAmountsOutCall {

--- a/example/swap.rs
+++ b/example/swap.rs
@@ -1,7 +1,10 @@
+use std::path::Path;
+
 use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
 use revm::primitives::{keccak256, TxKind};
@@ -38,8 +41,10 @@ async fn main() -> Result<()> {
     let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 
     // construct the database
-    let database_path = std::env::var("DB_PATH").unwrap().parse().unwrap();
-    let mut nodedb = NodeDB::new(database_path).unwrap();
+    let database_path: String = std::env::var("DB_PATH").unwrap();
+    let backend =
+        RethBackend::new(Path::new(database_path.as_str())).expect("failed to open Reth database");
+    let mut nodedb = NodeDB::new(backend);
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());


### PR DESCRIPTION
@Zacholme7 , how's it going? I've got a proposal for you, let me know what you think! =)

## Enhanced Backend Extensibility for NodeDB

`NodeDB` is primarily designed to interface directly with the `reth` database. However, its architecture has been extended to accommodate alternative backend implementations for accessing on-chain data, enabling its use in diverse scenarios beyond `reth`. Key use cases include:

- **In-Memory Backend for Testing**:  
  Unit and integration testing often necessitate a controlled environment free from external dependencies, such as a physical database. An in-memory backend implementing the `NodeDBBackend` trait can emulate blockchain behavior by storing data in memory-based structures (e.g., `HashMap`), offering a rapid and deterministic testing framework.

- **Support for Blockchains Incompatible with `reth`**:  
  `NodeDB` can be adapted for blockchains that do not support `reth` as a node. The introduction of the `NodeDBBackend` trait facilitates the development of alternative backends, such as those utilizing IPC, RPC, LevelDB, ensuring `NodeDB` remains functional and effective in such environments.

## Implemented Changes

- **`NodeDBBackend` Trait**:  
  Establishes a generic interface comprising methods (`basic_account`, `account_code`, `storage`, `block_hash`) that allows `NodeDB` to interact with any compliant backend, not limited to `reth`. This abstraction decouples `NodeDB` from specific database implementations, enhancing its versatility.

- **`RethBackend` Implementation**:  
  Encapsulates `reth`-specific functionality (e.g., `ProviderFactory` and `StateProviderBox`), maintaining compatibility with existing `reth`-based use cases while enabling `NodeDB` to operate independently of `reth` when alternative backends are employed.

- **Standardized Error Handling**:  
  Implements a `From<ProviderError>` conversion to `NodeDBError`, standardizing error management across diverse backend implementations. This ensures seamless integration of heterogeneous error systems, improving robustness and maintainability.
  
  
Note: If you like this idea, I can make nodedb asynchronous, so we can also use asynchronous backends.
  