### PR TITLE
feat: supports operations non-blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4731,6 +4731,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
+ "async-trait",
  "dotenv",
  "env_logger",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "swap"
 path = "example/swap.rs"
 
 [[bin]]
-name = "swap_async"
+name = "swap-async"
 path = "example/swap_async.rs"
 
 [[bin]]
@@ -28,11 +28,11 @@ name = "approval"
 path = "example/approval.rs"
 
 [[bin]]
-name = "approval_async"
+name = "approval-async"
 path = "example/approval_async.rs"
 
 [[bin]]
-name = "get_balance_slot"
+name = "get-balance-slot"
 path = "example/get_balance_slot.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ name = "swap"
 path = "example/swap.rs"
 
 [[bin]]
+name = "swap_async"
+path = "example/swap_async.rs"
+
+[[bin]]
 name = "quote"
 path = "example/quote.rs"
 
@@ -22,6 +26,10 @@ path = "example/custom_account.rs"
 [[bin]]
 name = "approval"
 path = "example/approval.rs"
+
+[[bin]]
+name = "approval_async"
+path = "example/approval_async.rs"
 
 [[bin]]
 name = "get_balance_slot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ env_logger = "0.11.8"
 log = "0.4.27"
 revm = { version = "22.0.1", features = ["alloydb"] }
 foldhash = "0.1.5"
+async-trait = "0.1.88"

--- a/example/approval.rs
+++ b/example/approval.rs
@@ -20,8 +20,7 @@ sol!(
     }
 );
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     dotenv::dotenv().ok();
 
     // on chain addresses
@@ -70,16 +69,7 @@ async fn main() -> Result<()> {
         spender: uniswap_router,
     }
     .abi_encode();
-
-    let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
-        .modify_tx_chained(|tx| {
-            tx.caller = account;
-            tx.kind = TxKind::Call(weth);
-            tx.value = U256::ZERO;
-            tx.data = allowance_calldata.into();
-        })
-        .build_mainnet();
+    evm.modify_tx(|tx| tx.data = allowance_calldata.into());
 
     let ref_tx = evm.replay_commit().unwrap();
 

--- a/example/approval_async.rs
+++ b/example/approval_async.rs
@@ -75,16 +75,7 @@ async fn main() -> Result<()> {
         spender: uniswap_router,
     }
     .abi_encode();
-
-    let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
-        .modify_tx_chained(|tx| {
-            tx.caller = account;
-            tx.kind = TxKind::Call(weth);
-            tx.value = U256::ZERO;
-            tx.data = allowance_calldata.into();
-        })
-        .build_mainnet();
+    evm.modify_tx(|tx| tx.data = allowance_calldata.into());
 
     let ref_tx = evm.replay_commit().unwrap();
 

--- a/example/approval_async.rs
+++ b/example/approval_async.rs
@@ -4,7 +4,8 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
-use node_db::NodeDBStorageSync;
+use node_db::NodeDBAsync;
+use node_db::NodeDBStorageAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -37,12 +38,16 @@ async fn main() -> Result<()> {
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());
-    nodedb.insert_account_storage(
-        weth,
-        balance_slot.into(),
-        U256::from(1e18),
-        InsertionType::OnChain, // weth has a corresponding onchain contract
-    )?;
+    nodedb
+        .insert_account_storage(
+            weth,
+            balance_slot.into(),
+            U256::from(1e18),
+            InsertionType::OnChain, // weth has a corresponding onchain contract
+        )
+        .await?;
+
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
 
     // setup approval call and commit the transaction
     let approve_calldata = ERC20Token::approveCall {
@@ -53,7 +58,7 @@ async fn main() -> Result<()> {
 
     // construct a new evm instance
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.kind = TxKind::Call(weth);
@@ -72,7 +77,7 @@ async fn main() -> Result<()> {
     .abi_encode();
 
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.kind = TxKind::Call(weth);

--- a/example/custom_account.rs
+++ b/example/custom_account.rs
@@ -14,8 +14,7 @@ use revm::{Context, ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext};
 // Generate contract bindings
 sol!(Counter, "example/counter.json");
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     // dummy addresses
     let counter_address = address!("A5C381211A406b48A073E954e6949B0D49506bc0");
     let caller = address!("0000000000000000000000000000000000000001");
@@ -54,15 +53,7 @@ async fn main() -> Result<()> {
     evm.replay_commit().unwrap();
 
     let getcount_calldata = Counter::getCountCall {}.abi_encode();
-    let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
-        .modify_tx_chained(|tx| {
-            tx.caller = caller;
-            tx.kind = TxKind::Call(counter_address);
-            tx.data = getcount_calldata.into();
-            tx.value = U256::ZERO;
-        })
-        .build_mainnet();
+    evm.modify_tx(|tx| tx.data = getcount_calldata.into());
 
     let ref_tx = evm.replay().unwrap().result;
 

--- a/example/custom_account.rs
+++ b/example/custom_account.rs
@@ -4,7 +4,6 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
-use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -41,9 +40,8 @@ async fn main() -> Result<()> {
     let increment_calldata = Counter::incrementCall {}.abi_encode();
 
     // construct the evm instance
-    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
+        .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
             tx.caller = caller;
             tx.kind = TxKind::Call(counter_address);
@@ -57,7 +55,7 @@ async fn main() -> Result<()> {
 
     let getcount_calldata = Counter::getCountCall {}.abi_encode();
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
+        .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
             tx.caller = caller;
             tx.kind = TxKind::Call(counter_address);

--- a/example/custom_account.rs
+++ b/example/custom_account.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -40,8 +41,9 @@ async fn main() -> Result<()> {
     let increment_calldata = Counter::incrementCall {}.abi_encode();
 
     // construct the evm instance
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = caller;
             tx.kind = TxKind::Call(counter_address);
@@ -55,7 +57,7 @@ async fn main() -> Result<()> {
 
     let getcount_calldata = Counter::getCountCall {}.abi_encode();
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = caller;
             tx.kind = TxKind::Call(counter_address);

--- a/example/custom_slot.rs
+++ b/example/custom_slot.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
-
-use alloy_primitives::{address, U256};
+use alloy_primitives::{address, Address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
@@ -19,8 +18,7 @@ sol!(
     }
 );
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     // on chain addresses
     let account = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
@@ -47,7 +45,7 @@ async fn main() -> Result<()> {
     let mut evm = Context::mainnet()
         .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
-            tx.caller = account;
+            tx.caller = Address::ZERO;
             tx.value = U256::ZERO;
             tx.data = balance_calldata.into();
             tx.kind = TxKind::Call(weth);

--- a/example/custom_slot.rs
+++ b/example/custom_slot.rs
@@ -5,6 +5,7 @@ use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
 use node_db::NodeDBAsync;
+use node_db::NodeDBStorageSync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -33,14 +34,12 @@ async fn main() -> Result<()> {
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());
-    nodedb
-        .insert_account_storage(
-            weth,
-            balance_slot.into(),
-            U256::from(1e18),
-            InsertionType::OnChain, // weth has a corresponding onchain contract
-        )
-        .await?;
+    nodedb.insert_account_storage(
+        weth,
+        balance_slot.into(),
+        U256::from(1e18),
+        InsertionType::OnChain, // weth has a corresponding onchain contract
+    )?;
 
     // setup our balance_of calldata
     let balance_calldata = ERC20Token::balanceOfCall { account }.abi_encode();

--- a/example/custom_slot.rs
+++ b/example/custom_slot.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -32,19 +33,22 @@ async fn main() -> Result<()> {
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());
-    nodedb.insert_account_storage(
-        weth,
-        balance_slot.into(),
-        U256::from(1e18),
-        InsertionType::OnChain, // weth has a corresponding onchain contract
-    )?;
+    nodedb
+        .insert_account_storage(
+            weth,
+            balance_slot.into(),
+            U256::from(1e18),
+            InsertionType::OnChain, // weth has a corresponding onchain contract
+        )
+        .await?;
 
     // setup our balance_of calldata
     let balance_calldata = ERC20Token::balanceOfCall { account }.abi_encode();
 
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // construct a new evm instance
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.value = U256::ZERO;

--- a/example/custom_slot.rs
+++ b/example/custom_slot.rs
@@ -4,7 +4,6 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
-use node_db::NodeDBAsync;
 use node_db::NodeDBStorageSync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
@@ -44,10 +43,9 @@ async fn main() -> Result<()> {
     // setup our balance_of calldata
     let balance_calldata = ERC20Token::balanceOfCall { account }.abi_encode();
 
-    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // construct a new evm instance
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
+        .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.value = U256::ZERO;

--- a/example/get_balance_slot.rs
+++ b/example/get_balance_slot.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use alloy_primitives::{address, U256};
@@ -6,11 +7,12 @@ use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
 use node_db::NodeDB;
+use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use revm::context::result::ExecutionResult;
+use revm::database::async_db::DatabaseAsyncRef;
 use revm::primitives::{Address, TxKind};
-use revm::{Context, DatabaseRef, ExecuteEvm, MainBuilder, MainContext};
-
+use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
 sol! {
     #[sol(rpc)]
     contract WETH {
@@ -30,10 +32,9 @@ async fn main() -> Result<()> {
     let database_path: String = std::env::var("DB_PATH").unwrap();
     let backend =
         RethBackend::new(Path::new(database_path.as_str())).expect("failed to open Reth database");
-    let mut nodedb = NodeDB::<RethBackend>::new(backend);
 
     let start = Instant::now();
-    let balance_slot = get_balance_slot(&mut nodedb, weth, account)?;
+    let balance_slot = get_balance_slot(backend, weth, account).await?;
     let duration = start.elapsed();
 
     println!(
@@ -44,16 +45,15 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn get_balance_slot(
-    nodedb: &mut NodeDB<RethBackend>,
-    token: Address,
-    account: Address,
-) -> Result<U256> {
+async fn get_balance_slot(backend: RethBackend, token: Address, account: Address) -> Result<U256> {
+    let mut nodedb = NodeDB::<RethBackend>::new(backend);
     nodedb.enable_tracing()?;
 
     let balanceof_calldata = WETH::balanceOfCall { account }.abi_encode();
+
+    let mut nodedb_async = NodeDBAsync::new(&mut nodedb).unwrap();
     let mut evm = Context::mainnet()
-        .with_db(&mut *nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = address!("0000000000000000000000000000000000000000");
             tx.kind = TxKind::Call(token);
@@ -67,12 +67,13 @@ fn get_balance_slot(
         result => return Err(anyhow!("balanceOf failed: {result:?}")),
     };
 
+    drop(nodedb_async);
     let accessed_slots = nodedb.get_accessed_slots(token)?;
     nodedb.disable_tracing();
 
     // Identify the storage slot whose value matches the expected balance
     for slot in &accessed_slots {
-        let slot_value = nodedb.storage_ref(token, *slot)?;
+        let slot_value = nodedb.storage_async_ref(token, *slot).await?;
         if slot_value == balance {
             return Ok(*slot);
         }

--- a/example/quote.rs
+++ b/example/quote.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
-
-use alloy_primitives::{address, U256};
+use alloy_primitives::{address, U256, Address};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
@@ -18,13 +17,10 @@ sol!(
     }
 );
 
-#[tokio::main]
-
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     dotenv::dotenv().ok();
 
     // on-chain addresses
-    let vitalik = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
     let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
     let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     let uniswap = address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D");
@@ -46,7 +42,7 @@ async fn main() -> Result<()> {
     let mut evm = Context::mainnet()
         .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
-            tx.caller = vitalik;
+            tx.caller = Address::ZERO;
             tx.value = U256::ZERO;
             tx.kind = TxKind::Call(uniswap);
             tx.data = out_call.into();

--- a/example/quote.rs
+++ b/example/quote.rs
@@ -5,7 +5,6 @@ use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
 use node_db::NodeDB;
-use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use revm::context::result::ExecutionResult;
 use revm::primitives::TxKind;
@@ -43,10 +42,9 @@ async fn main() -> Result<()> {
     }
     .abi_encode();
 
-    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // create evm instance and transact
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
+        .with_db(&mut nodedb)
         .modify_tx_chained(|tx| {
             tx.caller = vitalik;
             tx.value = U256::ZERO;

--- a/example/quote.rs
+++ b/example/quote.rs
@@ -5,6 +5,7 @@ use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
 use node_db::NodeDB;
+use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use revm::context::result::ExecutionResult;
 use revm::primitives::TxKind;
@@ -42,9 +43,10 @@ async fn main() -> Result<()> {
     }
     .abi_encode();
 
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // create evm instance and transact
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = vitalik;
             tx.value = U256::ZERO;

--- a/example/swap.rs
+++ b/example/swap.rs
@@ -31,8 +31,7 @@ sol!(
     }
 );
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     dotenv::dotenv().ok();
 
     // on chain addresses
@@ -86,17 +85,10 @@ async fn main() -> Result<()> {
         deadline: U256::MAX,
     }
     .abi_encode();
-
-    // set call to the router
-    let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
-        .modify_tx_chained(|tx| {
-            tx.caller = account;
-            tx.value = U256::ZERO;
-            tx.kind = TxKind::Call(uniswap_router);
-            tx.data = calldata.into();
-        })
-        .build_mainnet();
+    evm.modify_tx(|tx| {
+        tx.data = calldata.into();
+        tx.kind = TxKind::Call(uniswap_router);
+    });
 
     // if we can transact, add it as it is a valid pool. Else ignore it
     let ref_tx = evm.replay_commit().unwrap();

--- a/example/swap.rs
+++ b/example/swap.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
+use node_db::NodeDBAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
@@ -48,12 +49,14 @@ async fn main() -> Result<()> {
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());
-    nodedb.insert_account_storage(
-        weth,
-        balance_slot.into(),
-        U256::from(1e18),
-        InsertionType::OnChain, // weth has a corresponding onchain contract
-    )?;
+    nodedb
+        .insert_account_storage(
+            weth,
+            balance_slot.into(),
+            U256::from(1e18),
+            InsertionType::OnChain, // weth has a corresponding onchain contract
+        )
+        .await?;
 
     // setup approval call and commit the transaction
     let approve_calldata = ERC20Token::approveCall {
@@ -61,9 +64,11 @@ async fn main() -> Result<()> {
         amount: U256::from(10e18),
     }
     .abi_encode();
+
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // construct a new evm instance
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.value = U256::ZERO;
@@ -88,7 +93,7 @@ async fn main() -> Result<()> {
 
     // set call to the router
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
             tx.value = U256::ZERO;

--- a/example/swap_async.rs
+++ b/example/swap_async.rs
@@ -91,17 +91,10 @@ async fn main() -> Result<()> {
         deadline: U256::MAX,
     }
     .abi_encode();
-
-    // set call to the router
-    let mut evm = Context::mainnet()
-        .with_db(&mut nodedb_async)
-        .modify_tx_chained(|tx| {
-            tx.caller = account;
-            tx.value = U256::ZERO;
-            tx.kind = TxKind::Call(uniswap_router);
-            tx.data = calldata.into();
-        })
-        .build_mainnet();
+    evm.modify_tx(|tx| {
+        tx.data = calldata.into();
+        tx.kind = TxKind::Call(uniswap_router);
+    });
 
     // if we can transact, add it as it is a valid pool. Else ignore it
     let ref_tx = evm.replay_commit().unwrap();

--- a/example/swap_async.rs
+++ b/example/swap_async.rs
@@ -4,19 +4,31 @@ use alloy_primitives::{address, U256};
 use alloy_sol_types::{sol, SolCall, SolValue};
 use eyre::anyhow;
 use eyre::Result;
-use node_db::NodeDBStorageSync;
+use node_db::NodeDBAsync;
+use node_db::NodeDBStorageAsync;
 use node_db::RethBackend;
 use node_db::{InsertionType, NodeDB};
 use revm::context::result::ExecutionResult;
 use revm::primitives::{keccak256, TxKind};
 use revm::{Context, ExecuteCommitEvm, MainBuilder, MainContext};
 
-// Approval and Allowance function signatures
+sol!(
+    #[sol(rpc)]
+    contract V2Swap {
+        function swapExactTokensForTokens(
+            uint256 amountIn,
+            uint256 amountOutMin,
+            address[] calldata path,
+            address to,
+            uint256 deadline
+        ) external returns (uint256[] memory amounts);
+    }
+);
+
 sol!(
     #[sol(rpc)]
     contract ERC20Token {
         function approve(address spender, uint256 amount) external returns (bool success);
-        function allowance(address owner, address spender) public view returns (uint256);
     }
 );
 
@@ -28,6 +40,7 @@ async fn main() -> Result<()> {
     let account = address!("0000000000000000000000000000000000000001");
     let uniswap_router = address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D");
     let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 
     // construct the database
     let database_path: String = std::env::var("DB_PATH").unwrap();
@@ -37,12 +50,14 @@ async fn main() -> Result<()> {
 
     // give our account some weth
     let balance_slot = keccak256((account, U256::from(3)).abi_encode());
-    nodedb.insert_account_storage(
-        weth,
-        balance_slot.into(),
-        U256::from(1e18),
-        InsertionType::OnChain, // weth has a corresponding onchain contract
-    )?;
+    nodedb
+        .insert_account_storage(
+            weth,
+            balance_slot.into(),
+            U256::from(1e18),
+            InsertionType::OnChain, // weth has a corresponding onchain contract
+        )
+        .await?;
 
     // setup approval call and commit the transaction
     let approve_calldata = ERC20Token::approveCall {
@@ -51,45 +66,55 @@ async fn main() -> Result<()> {
     }
     .abi_encode();
 
+    let mut nodedb_async = NodeDBAsync::new(nodedb).unwrap();
     // construct a new evm instance
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
-            tx.kind = TxKind::Call(weth);
             tx.value = U256::ZERO;
+            tx.kind = TxKind::Call(weth);
             tx.data = approve_calldata.into();
         })
         .build_mainnet();
 
     evm.replay_commit().unwrap();
 
-    // now confirm the allowance for the router
-    let allowance_calldata = ERC20Token::allowanceCall {
-        owner: account,
-        spender: uniswap_router,
+    // we now have some of the input token and we have approved the router to spend it
+
+    // setup calldata based on the swap type
+    let calldata = V2Swap::swapExactTokensForTokensCall {
+        amountIn: U256::from(1e18),
+        amountOutMin: U256::ZERO,
+        path: vec![weth, usdc],
+        to: account,
+        deadline: U256::MAX,
     }
     .abi_encode();
 
+    // set call to the router
     let mut evm = Context::mainnet()
-        .with_db(&mut nodedb)
+        .with_db(&mut nodedb_async)
         .modify_tx_chained(|tx| {
             tx.caller = account;
-            tx.kind = TxKind::Call(weth);
             tx.value = U256::ZERO;
-            tx.data = allowance_calldata.into();
+            tx.kind = TxKind::Call(uniswap_router);
+            tx.data = calldata.into();
         })
         .build_mainnet();
 
+    // if we can transact, add it as it is a valid pool. Else ignore it
     let ref_tx = evm.replay_commit().unwrap();
-
     let output = match ref_tx {
         ExecutionResult::Success { output, .. } => output,
         result => return Err(anyhow!("'swap' execution failed: {result:?}")),
     };
 
-    let allowance = <U256>::abi_decode(output.data()).unwrap();
-    println!("The router is allowed to spend {:?} weth", allowance);
+    let decoded_outputs = <Vec<U256>>::abi_decode(output.data()).unwrap();
+    println!(
+        "Swapped 1 WETH for {} USDC",
+        decoded_outputs.get(1).unwrap()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Convert NodeDB to fully asynchronous API and add NodeDBAsync wrapper

- Introduce DatabaseAsync and DatabaseAsyncRef traits on NodeDB and &mut NodeDB to expose non-blocking futures for basic_account, account_code, storage, and block_hash.

- Replace synchronous insert_account_storage with an async version on NodeDB.

- Add NodeDBAsync<T> wrapper that implements Database, DatabaseRef and now also DatabaseCommit, delegating to the inner async backend and Tokio runtime handle.

- Ensure tracing of accessed storage slots works in async context and commit logic is preserved for EVM execution (replay_commit).